### PR TITLE
Comment out cv2.imshow and cv2.waitKey

### DIFF
--- a/Table Structure Recognition/Functions/borderFunc.py
+++ b/Table Structure Recognition/Functions/borderFunc.py
@@ -51,8 +51,8 @@ def extract_table(table_body,__line__,lines=None):
         for x,y in point:
             cv2.line(table,(x,y),(x,y),(0,0,255),8)
 
-    cv2.imshow("intersection",table)
-    cv2.waitKey(0)
+    # cv2.imshow("intersection",table)
+    # cv2.waitKey(0)
 
     # boxno = -1
     box = []

--- a/Table Structure Recognition/Functions/line_detection.py
+++ b/Table Structure Recognition/Functions/line_detection.py
@@ -9,8 +9,8 @@ def line_detection(image):
     bw = cv2.adaptiveThreshold(gray, 255, cv2.ADAPTIVE_THRESH_MEAN_C, cv2.THRESH_BINARY, 15, 1)
     bw = cv2.bitwise_not(bw)
     ## To visualize image after thresholding ##
-    cv2.imshow("bw",bw)
-    cv2.waitKey(0)
+    # cv2.imshow("bw",bw)
+    # cv2.waitKey(0)
     ###########################################
     horizontal = bw.copy()
     vertical = bw.copy()


### PR DESCRIPTION
Using cv2.imshow and cv2.waitKey causes errors in Google Colab. I have commented them out so that people starting out can run the google colab notebook without any issues. If this is not something you want, feel free to close the PR without merging it.